### PR TITLE
Add crosslink for directions to at-event page

### DIFF
--- a/lib/views/pages/location.html
+++ b/lib/views/pages/location.html
@@ -23,7 +23,18 @@
             </li>
         </ul>
 
-        <h3>Find the location on the map</h3>
+
+        <hr class="atevent_divider">
+        <div class="theme theme-atevent">
+            <blockquote>
+                How to get there…
+            </blockquote>
+        </div>
+        <h3 id="directions" class="atevent_headline">Get To The Event</h3>
+        <p>More information about how to get to the location can be found on our <a href="/atevent#directions">At The Event page</a>.</p>
+
+        <hr class="atevent_divider">
+        <h3 id="map" class="atevent_headline">Find the location on the map</h3>
 
         <p>The venue is located in the center of Cologne Ehrenfeld, one of the neighbourhoods where youth like to meet—with a lot of small cafés, bars, restaurants and clubs. <br>
         Bahnhof Ehrenfeld is just around the corner and the subway station Körnerstraße (line 3 and 4) is also in 5 minute walking distance.</p>

--- a/scss/main.scss
+++ b/scss/main.scss
@@ -1058,7 +1058,8 @@ input[type='submit'] {
     }
 }
 
-.atevent h3 {
+.atevent h3,
+.atevent_headline {
     display: inline-block;
     font-size: 2em;
     padding: 0.25em;
@@ -1066,12 +1067,14 @@ input[type='submit'] {
     color: #263238;
 }
 
-.atevent hr {
+.atevent hr,
+.atevent_divider {
     border-color: transparent;
     margin: 5em auto 1em;
 }
 
-.atevent .theme {
+.atevent .theme,
+.theme-atevent {
     margin-bottom: 0;
 }
 


### PR DESCRIPTION
This PR adds a crosslink from the location page to the section "Directions" on the At The Event page.
